### PR TITLE
Add ruby version appoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.0'
+
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'


### PR DESCRIPTION
- 目的
  Rubyのバージョンがしていされていないのでrails sが失敗することの対策
- 実装
  Gemfile にruby '2.3.0'を追加
